### PR TITLE
[OPPREF] Fix rubocop rules for all repos

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 Rails:
   Enabled: true
 AllCops:
@@ -7,7 +9,7 @@ AllCops:
     - vendor/bundle/**/*
 
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
When running in guest-house or vincari-rails, we get an error when
trying to run `./bin/test` using the settings in the `.rubocop.yml`
file.

```
== Linting ==
.rubocop-https---raw-githubusercontent-com-ComplyMD-dotfiles-master--rubocop-yml:
Metrics/LineLength has the wrong namespace - should be Layout
Error: obsolete `EnforcedStyle: rails` (for
Layout/IndentationConsistency) found in
.rubocop-https---raw-githubusercontent-com-ComplyMD-dotfiles-master--rubocop-yml
`EnforcedStyle: rails` has been renamed to `EnforcedStyle: indented_internal_methods`
```

These changes update that.